### PR TITLE
Fix #6 - Safari game: sounds, card counts, and back button

### DIFF
--- a/games/animal-safari/data.js
+++ b/games/animal-safari/data.js
@@ -92,14 +92,14 @@ const ANIMAL_SOUNDS = {
 // Difficulty configurations
 const DIFFICULTY_CONFIG = {
     easy: {
-        pairs: 6,
-        animals: ANIMALS.slice(0, 6),
+        pairs: 3,
+        animals: ANIMALS.slice(0, 3),
         timer: null,
         gridClass: 'easy'
     },
     medium: {
-        pairs: 8,
-        animals: ANIMALS,
+        pairs: 6,
+        animals: ANIMALS.slice(0, 6),
         timer: 180, // 3 minutes
         gridClass: 'medium'
     },

--- a/games/animal-safari/index.html
+++ b/games/animal-safari/index.html
@@ -79,6 +79,9 @@
 
         <!-- Game Screen -->
         <div id="game-screen" class="screen">
+            <div class="game-nav">
+                <button class="back-btn" id="back-to-game-menu">🔙 תפריט</button>
+            </div>
             <div class="game-header">
                 <div class="stat-item">
                     <span class="stat-label">נקודות:</span>

--- a/games/animal-safari/main.js
+++ b/games/animal-safari/main.js
@@ -125,8 +125,18 @@ function setupEventListeners() {
     // Play again button
     document.getElementById('play-again').addEventListener('click', handleStartGame);
 
-    // Back to menu button
+    // Back to menu button (complete screen)
     document.getElementById('back-to-menu').addEventListener('click', () => {
+        showScreen('welcome-screen');
+        resetGame();
+    });
+
+    // Back to menu button (game screen)
+    document.getElementById('back-to-game-menu').addEventListener('click', () => {
+        if (GameState.timerInterval) {
+            clearInterval(GameState.timerInterval);
+            GameState.timerInterval = null;
+        }
         showScreen('welcome-screen');
         resetGame();
     });
@@ -284,8 +294,12 @@ function handleCardClick(cardId) {
     cardElement.classList.add('flipped');
     GameState.flippedCards.push(cardData);
 
-    // Play flip sound
-    playSound('flip');
+    // Play flip sound (or animal sound in sound mode)
+    if (GameState.mode === 'sound') {
+        playAnimalSound(cardData.animal);
+    } else {
+        playSound('flip');
+    }
 
     // Check for match if two cards flipped
     if (GameState.flippedCards.length === 2) {
@@ -397,9 +411,15 @@ function completeGame() {
 }
 
 function updateStars() {
-    if (GameState.moves > 30) {
+    const thresholds = {
+        easy:   { two: 4,  one: 7  },
+        medium: { two: 10, one: 18 },
+        hard:   { two: 14, one: 24 }
+    };
+    const t = thresholds[GameState.difficulty];
+    if (GameState.moves > t.one) {
         GameState.stars = 1;
-    } else if (GameState.moves > 20) {
+    } else if (GameState.moves > t.two) {
         GameState.stars = 2;
     } else {
         GameState.stars = 3;

--- a/games/animal-safari/styles.css
+++ b/games/animal-safari/styles.css
@@ -245,6 +245,32 @@ body {
     padding-top: 80px;
 }
 
+.game-nav {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 20px 10px;
+}
+
+.back-btn {
+    background: rgba(255, 255, 255, 0.5);
+    border: 2px solid rgba(255, 255, 255, 0.7);
+    border-radius: 20px;
+    padding: 8px 18px;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-family: inherit;
+    transition: var(--transition);
+    backdrop-filter: blur(10px);
+}
+
+.back-btn:hover {
+    background: rgba(255, 255, 255, 0.8);
+    transform: scale(1.05);
+}
+
 .game-header {
     display: flex;
     justify-content: center;
@@ -301,11 +327,11 @@ body {
 }
 
 .card-grid.medium {
-    grid-template-columns: repeat(4, 140px);
+    grid-template-columns: repeat(4, 130px);
 }
 
 .card-grid.hard {
-    grid-template-columns: repeat(4, 140px);
+    grid-template-columns: repeat(4, 130px);
 }
 
 /* ==========================================


### PR DESCRIPTION
## Summary

- **Sound mode card sounds**: Every card flip in sound mode now plays the animal's sound, including the second card — so players hear the sound before mismatched cards flip back
- **Difficulty card counts**: Easy = 3 pairs (6 cards), Medium = 6 pairs (12 cards), Hard = 8 pairs (16 cards) — proper difficulty curve
- **Back button in game screen**: Added a `🔙 תפריט` button at the top of the game screen to return to the safari welcome screen; the `🏠` home button still navigates to the main platform
- **Difficulty-aware star thresholds**: Easy 4/7 moves, Medium 10/18, Hard 14/24 — so easy mode can realistically earn 3 stars

## Test plan

- [ ] Start a Sound mode game, click a card → animal sound plays
- [ ] Click a second card that doesn't match → second sound plays, then cards flip back
- [ ] Verify easy = 6 cards, medium = 12 cards, hard = 16 cards
- [ ] Click 🔙 תפריט during a game → returns to safari welcome screen
- [ ] Click 🏠 → still goes to main platform
- [ ] Play easy mode to completion with few mistakes → should earn 3 stars

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)