### PR TITLE
Fix mobile voice feedback in color-code: remove setTimeout from speakText()

### DIFF
--- a/games/color-code/main.js
+++ b/games/color-code/main.js
@@ -72,15 +72,18 @@ async function unlockAudio() {
 
 function speakText(text) {
     if (!('speechSynthesis' in window)) return;
+    // Cancel any current speech, then speak synchronously.
+    // IMPORTANT: on iOS Safari, calling speak() inside setTimeout (even 50ms)
+    // places it outside the user-gesture context after cancel() resets iOS's
+    // internal speech permission state — causing silent failures on mobile.
+    // Calling speak() synchronously keeps it within the gesture context.
     speechSynthesis.cancel();
-    setTimeout(() => {
-        const u = new SpeechSynthesisUtterance(text);
-        u.lang  = 'he-IL';
-        u.rate  = 0.85;
-        u.pitch = 1.1;
-        if (hebrewVoice) u.voice = hebrewVoice;
-        speechSynthesis.speak(u);
-    }, 50);
+    const u = new SpeechSynthesisUtterance(text);
+    u.lang  = 'he-IL';
+    u.rate  = 0.85;
+    u.pitch = 1.1;
+    if (hebrewVoice) u.voice = hebrewVoice;
+    speechSynthesis.speak(u);
 }
 
 /* ─── TOUCH DEDUPLICATION ──────────────────────────── */


### PR DESCRIPTION
On iOS Safari, calling speechSynthesis.cancel() resets the browser's
internal speech permission state. The subsequent speak() call deferred
via setTimeout (even 50ms) falls outside the user-gesture execution
context, causing iOS to silently drop all voice feedback after submit.

Fix: call speak() synchronously immediately after cancel(). The session
is already unlocked by the warmup utterance in unlockAudio(), so staying
synchronous within the touchstart handler keeps iOS speech working.

https://claude.ai/code/session_01VvfAgp6wZ8dVFqKwMTxZF9