### PR TITLE
Fix הרגשות שלי game: image, start button on mobile, spelling

### DIFF
--- a/.agent/agents/game-designer.md
+++ b/.agent/agents/game-designer.md
@@ -212,10 +212,13 @@ Before declaring a game "done", verify:
 - [ ] Three screens exist: welcome, game, complete
 - [ ] `data.js` is separate from `main.js`
 - [ ] All required CSS variables defined
+- [ ] `startGame()` calls `unlockAudio()` fire-and-forget — game must NOT wait on `.then()` to switch screens
+- [ ] `waitForVoices()` has a 3-second timeout safety net (Android `onvoiceschanged` can hang forever)
 - [ ] Audio unlocked on first user gesture
 - [ ] Works on iPhone SE (375px wide) without horizontal scroll
 - [ ] Touch events on all interactive elements
-- [ ] Registered in `platform/games.json`
+- [ ] Registered in `platform/games.json` with a real SVG image path (not an emoji string)
+- [ ] Thumbnail SVG created at `platform/images/<game-id>.svg`
 - [ ] **Mobile tester has reviewed the game** — run `/mobile-test games/<game-id>/` and fix all ❌ items before opening PR
 
 ---
@@ -227,3 +230,5 @@ Always study `games/hebrew-writer/` before starting a new game. It's the gold st
 - `styles.css` — full design system with all CSS variables, animations, responsive
 - `main.js` — audio unlock, screen navigation, touch events, game state management
 - `data.js` — clean data structure with content, config, and messages
+
+Also study `games/feelings-match/main.js` for the fire-and-forget audio unlock pattern required since PR #14.

--- a/.agent/agents/mobile-tester.md
+++ b/.agent/agents/mobile-tester.md
@@ -186,8 +186,32 @@ Produce a clear report:
 - Safari voice issues: voices don't load until after a user gesture — warmup pattern required
 - color-code (main branch): `speechSynthesis` feedback was silenced forever because `unlockAudio()` called `await` before the warmup `speak()`. The `await` breaks the iOS gesture chain. Fix: warmup `speak()` must be the first statement in `unlockAudio()`, before any `await`.
 - color-code (main branch): SFX silent on first tap because `playTone()` returned without playing when `AudioContext` was suspended. Fix: resume and retry the tone via `.then()` instead of returning.
+- feelings-match (PR #14): Start button did nothing on mobile because `startGame()` was gated behind `unlockAudio().then(...)`. On Android, `waitForVoices()` hangs when `onvoiceschanged` never fires. Fixes: (1) call `unlockAudio()` fire-and-forget, start game immediately; (2) add 3s timeout to `waitForVoices()`.
 
-**Reference for correct patterns**: `games/hebrew-writer/main.js` and `games/hebrew-writer/index.html`
+**`waitForVoices()` must always have a timeout (Android safety net):**
+```javascript
+function waitForVoices() {
+    return new Promise((resolve) => {
+        if (!('speechSynthesis' in window)) { resolve(); return; }
+        const voices = speechSynthesis.getVoices();
+        if (voices.length > 0) { hebrewVoice = findHebrewVoice(); resolve(); return; }
+        const timeout = setTimeout(() => { hebrewVoice = findHebrewVoice(); resolve(); }, 3000);
+        speechSynthesis.onvoiceschanged = () => { clearTimeout(timeout); hebrewVoice = findHebrewVoice(); resolve(); };
+    });
+}
+```
+
+**`startGame()` must never block on `unlockAudio()`:**
+```javascript
+function startGame() {
+    unlockAudio().catch(() => {}); // fire-and-forget — iOS speak() fires synchronously before any await
+    buildQuestions();
+    showScreen('game-screen');
+    showQuestion();
+}
+```
+
+**Reference for correct patterns**: `games/hebrew-writer/main.js`, `games/hebrew-writer/index.html`, and `games/feelings-match/main.js` (fire-and-forget audio pattern)
 
 **Where to check audio unlock**: look for `unlockAudio()` function called in the start button handler
 

--- a/.claude/commands/mobile-test.md
+++ b/.claude/commands/mobile-test.md
@@ -28,11 +28,11 @@ Read the game's three files: `index.html`, `styles.css`, and `main.js`. Then pro
 - Does `touchstart` use `e.preventDefault()` and `{ passive: false }`?
 - Is `AudioContext` created lazily (NOT on page load — only on user gesture)?
 - Is `audioContext.resume()` called inside the user gesture handler?
-- Is there a `waitForVoices()` function or equivalent that handles async voice loading via `onvoiceschanged`?
+- Is there a `waitForVoices()` function with a **3-second timeout** fallback (not just `onvoiceschanged`)? — required to prevent game freeze on Android
 - Is there a warmup utterance (volume 0.01, rate 2) fired on first user interaction?
 - Is `speechSynthesis.cancel()` called before every new utterance?
 - Is there graceful handling when Hebrew voice (`he-IL`) is unavailable?
-- Does the start button handler call `unlockAudio()` (or equivalent) before starting the game?
+- Does the start button handler call `unlockAudio()` **fire-and-forget** (not `.then()`)? — game must start immediately without waiting for audio to resolve
 
 ## Report Format
 

--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -120,6 +120,8 @@ const TRY_AGAIN = [...]; // Hebrew phrases
 
 ## Step 4: Register the Game
 
+Create a thumbnail SVG at `platform/images/[game-id].svg` — an emoji string in the image field will NOT render. Look at `platform/images/feelings_match.svg` as a reference: a colored background rect with SVG shapes or text representing the game theme.
+
 Add the game to `platform/games.json`:
 ```json
 {
@@ -127,11 +129,19 @@ Add the game to `platform/games.json`:
     "title": "[Hebrew title]",
     "description": "[1 sentence in Hebrew]",
     "path": "games/[game-id]/index.html",
-    "image": "🎮"
+    "image": "platform/images/[game-id].svg"
 }
 ```
 
-Use an appropriate emoji for the image field that represents the game theme.
+Also ensure `startGame()` calls `unlockAudio()` fire-and-forget — never gate the screen switch on audio resolving:
+```javascript
+function startGame() {
+    unlockAudio().catch(() => {}); // fire-and-forget
+    buildQuestions();
+    showScreen('game-screen');
+    showQuestion();
+}
+```
 
 ## Step 5: Verify
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,21 @@ Preserve compatibility with existing games
 
 When specs and implementation disagree, specs are the source of truth.
 
+Mobile Audio Critical Pattern
+
+When implementing startGame() in any game, never make the game start conditional on unlockAudio() resolving. Call unlockAudio() fire-and-forget so iOS Safari gets the synchronous speak() call inside the user gesture, and start the game immediately after:
+
+  unlockAudio().catch(() => {});   // fire-and-forget — speak() runs synchronously before any await
+  buildQuestions();
+  showScreen('game-screen');
+  showQuestion();
+
+Always add a 3-second timeout to waitForVoices() so the game never hangs on Android devices where onvoiceschanged never fires.
+
+Game Thumbnail Images
+
+Every entry in platform/games.json must have a real image path (SVG or PNG in platform/images/) for the "image" field. An emoji string will not render correctly as a card thumbnail. Create an SVG in platform/images/<game-id>.svg and reference it as "platform/images/<game-id>.svg".
+
 Out of Scope
 
 User accounts

--- a/games/feelings-match/index.html
+++ b/games/feelings-match/index.html
@@ -61,7 +61,7 @@
 
                 <!-- Start button -->
                 <button class="magic-btn" id="start-btn">
-                    <span>בואו נשחק!</span>
+                    <span>בואו לשחק!</span>
                     <span>❤️</span>
                 </button>
 

--- a/games/feelings-match/main.js
+++ b/games/feelings-match/main.js
@@ -51,7 +51,10 @@ function waitForVoices() {
             resolve();
             return;
         }
+        /* Timeout safety net — on some Android devices onvoiceschanged never fires */
+        const timeout = setTimeout(() => { hebrewVoice = findHebrewVoice(); resolve(); }, 3000);
         speechSynthesis.onvoiceschanged = () => {
+            clearTimeout(timeout);
             hebrewVoice = findHebrewVoice();
             resolve();
         };
@@ -336,17 +339,20 @@ function showComplete() {
 ═══════════════════════════════════════════════════════ */
 
 function startGame() {
-    /* RULE: unlockAudio() must be called here, inside the button handler */
-    unlockAudio().then(() => {
-        score        = 0;
-        correctCount = 0;
-        currentIndex = 0;
-        answered     = false;
-        document.getElementById('score-display').textContent = '⭐ 0';
-        buildQuestions();
-        showScreen('game-screen');
-        showQuestion();
-    });
+    /* RULE: unlockAudio() must be called here, inside the button handler.
+       Fire-and-forget — speak() fires synchronously before any await (iOS safe).
+       The game must NOT wait for audio to resolve; waitForVoices() can hang on
+       some Android devices when onvoiceschanged never fires. */
+    unlockAudio().catch(() => {});
+
+    score        = 0;
+    correctCount = 0;
+    currentIndex = 0;
+    answered     = false;
+    document.getElementById('score-display').textContent = '⭐ 0';
+    buildQuestions();
+    showScreen('game-screen');
+    showQuestion();
 }
 
 /* ═══════════════════════════════════════════════════════

--- a/platform/games.json
+++ b/platform/games.json
@@ -102,6 +102,6 @@
     "title": "הרגשות שלי",
     "description": "למד על רגשות בעברית! ראה סיטואציה ובחר את הפרצוף הנכון 😊😢😠",
     "path": "games/feelings-match/index.html",
-    "image": "❤️"
+    "image": "platform/images/feelings_match.svg"
   }
 ]

--- a/platform/images/feelings_match.svg
+++ b/platform/images/feelings_match.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2d1b69"/>
+      <stop offset="50%" stop-color="#11998e"/>
+      <stop offset="100%" stop-color="#38ef7d"/>
+    </linearGradient>
+    <linearGradient id="heartGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f857a6"/>
+      <stop offset="100%" stop-color="#ff5858"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="200" height="200" rx="22" fill="url(#bg)"/>
+
+  <!-- Heart shape (center) -->
+  <path d="M100 140 C60 110, 38 88, 38 68 C38 50, 52 38, 68 38 C80 38, 90 45, 100 55 C110 45, 120 38, 132 38 C148 38, 162 50, 162 68 C162 88, 140 110, 100 140 Z" fill="url(#heartGrad)" opacity="0.95"/>
+
+  <!-- Happy face (top-left) -->
+  <circle cx="44" cy="44" r="18" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="1.5"/>
+  <circle cx="39" cy="41" r="2.2" fill="#fff"/>
+  <circle cx="49" cy="41" r="2.2" fill="#fff"/>
+  <path d="M38 47 Q44 52 50 47" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Sad face (top-right) -->
+  <circle cx="156" cy="44" r="18" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="1.5"/>
+  <circle cx="151" cy="41" r="2.2" fill="#fff"/>
+  <circle cx="161" cy="41" r="2.2" fill="#fff"/>
+  <path d="M150 49 Q156 44 162 49" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Angry face (bottom-left) -->
+  <circle cx="44" cy="156" r="18" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="1.5"/>
+  <circle cx="39" cy="153" r="2.2" fill="#fff"/>
+  <circle cx="49" cy="153" r="2.2" fill="#fff"/>
+  <path d="M37 148 L42 151" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M51 148 L46 151" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M38 160 Q44 156 50 160" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Surprised face (bottom-right) -->
+  <circle cx="156" cy="156" r="18" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="1.5"/>
+  <circle cx="151" cy="153" r="2.2" fill="#fff"/>
+  <circle cx="161" cy="153" r="2.2" fill="#fff"/>
+  <ellipse cx="156" cy="161" rx="4" ry="5" fill="none" stroke="#fff" stroke-width="2"/>
+
+  <!-- White sparkles -->
+  <text x="100" y="178" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.7)" font-family="sans-serif">הרגשות שלי</text>
+</svg>


### PR DESCRIPTION
- Add platform/images/feelings_match.svg thumbnail (fixes broken card image)
- Fix games.json: replace emoji string with real SVG image path
- Fix index.html: spelling בואו נשחק → בואו לשחק
- Fix main.js: startGame() now fire-and-forgets unlockAudio() so the
  game starts immediately without blocking on waitForVoices() — which
  can hang indefinitely on Android when onvoiceschanged never fires
- Fix main.js: add 3-second timeout to waitForVoices() as safety net
- Update AGENTS.md, mobile-tester.md, game-designer.md, mobile-test
  command, and new-game command to document both patterns as required
  going forward

Fixes #14

https://claude.ai/code/session_019FYnJYg4T3fh5CNQAfBwLi