### PR TITLE
Fix audio in color-code and feelings-match games

### DIFF
--- a/.agent/agents/game-designer.md
+++ b/.agent/agents/game-designer.md
@@ -215,6 +215,9 @@ Before declaring a game "done", verify:
 - [ ] `startGame()` calls `unlockAudio()` fire-and-forget — game must NOT wait on `.then()` to switch screens
 - [ ] `waitForVoices()` has a 3-second timeout safety net (Android `onvoiceschanged` can hang forever)
 - [ ] Audio unlocked on first user gesture
+- [ ] `speakText()` calls `speak()` **synchronously** after `cancel()` — NOT inside a `setTimeout` (see Audio Rules below)
+- [ ] Speaker button handler calls `unlockAudio().catch(() => {})` before speaking (in case AudioContext was suspended)
+- [ ] No CSS rule sets `.feedback-caption { display: none }` — feedback text must be visible after guesses
 - [ ] Works on iPhone SE (375px wide) without horizontal scroll
 - [ ] Touch events on all interactive elements
 - [ ] Registered in `platform/games.json` with a real SVG image path (not an emoji string)
@@ -223,12 +226,66 @@ Before declaring a game "done", verify:
 
 ---
 
+## Audio Rules (Enforced — Do Not Deviate)
+
+These rules come from bugs found in production games. Read before writing any audio code.
+
+### Rule A — `speakText()` must call `speak()` synchronously
+
+```javascript
+// CORRECT
+function speakText(text) {
+    if (!('speechSynthesis' in window)) return;
+    speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text.replace(/[?!.,;:]/g, ''));
+    u.lang = 'he-IL';
+    u.rate = 0.8;
+    if (hebrewVoice) u.voice = hebrewVoice;
+    speechSynthesis.speak(u);   // ← synchronous, NOT in setTimeout
+}
+
+// WRONG — breaks iOS Safari speaker button
+function speakText(text) {
+    speechSynthesis.cancel();
+    setTimeout(() => {
+        speechSynthesis.speak(...);  // ← cancel() resets iOS permission, then this fires outside gesture context → silent
+    }, 50);
+}
+```
+
+### Rule B — `waitForVoices()` must have a 3-second timeout
+
+```javascript
+function waitForVoices() {
+    return new Promise((resolve) => {
+        if (!('speechSynthesis' in window)) { resolve(); return; }
+        const voices = speechSynthesis.getVoices();
+        if (voices.length > 0) { hebrewVoice = findHebrewVoice(); resolve(); return; }
+        // Safety net: onvoiceschanged never fires on some Android devices
+        const timeout = setTimeout(() => { hebrewVoice = findHebrewVoice(); resolve(); }, 3000);
+        speechSynthesis.onvoiceschanged = () => { clearTimeout(timeout); hebrewVoice = findHebrewVoice(); resolve(); };
+    });
+}
+```
+
+Without the timeout, if `onvoiceschanged` never fires, `hebrewVoice` stays `null` permanently and all speech is silent.
+
+### Rule C — Speaker button must re-call `unlockAudio()`
+
+```javascript
+addBtn('speaker-btn', () => {
+    unlockAudio().catch(() => {});  // ← re-unlock if AudioContext was suspended
+    const item = questions[currentIndex];
+    if (item) speakScene(item);
+});
+```
+
+### Rule D — Feedback text CSS must be visible
+
+Never add `display: none` to `.feedback-caption` or any element that shows per-guess feedback. The text is generated dynamically; hiding it in CSS silently breaks the whole feedback system.
+
+---
+
 ## The Reference Implementation
 
-Always study `games/hebrew-writer/` before starting a new game. It's the gold standard:
-- `index.html` — correct structure, all required meta tags, three screens
-- `styles.css` — full design system with all CSS variables, animations, responsive
-- `main.js` — audio unlock, screen navigation, touch events, game state management
-- `data.js` — clean data structure with content, config, and messages
-
-Also study `games/feelings-match/main.js` for the fire-and-forget audio unlock pattern required since PR #14.
+Always study `games/color-code/main.js` for the canonical audio pattern (synchronous `speakText`, timeout in `waitForVoices`). Also study `games/feelings-match/main.js` for the fire-and-forget `unlockAudio()` pattern and the speaker button pattern.

--- a/games/color-code/main.js
+++ b/games/color-code/main.js
@@ -36,7 +36,10 @@ function waitForVoices() {
             resolve();
             return;
         }
+        /* Timeout safety net — on some Android devices onvoiceschanged never fires */
+        const timeout = setTimeout(() => { hebrewVoice = findHebrewVoice(); resolve(); }, 3000);
         speechSynthesis.onvoiceschanged = () => {
+            clearTimeout(timeout);
             hebrewVoice = findHebrewVoice();
             resolve();
         };

--- a/games/color-code/styles.css
+++ b/games/color-code/styles.css
@@ -505,7 +505,10 @@ body {
 }
 
 .feedback-caption {
-    display: none;
+    font-size: clamp(0.7rem, 2.5vw, 0.82rem);
+    color: rgba(255, 255, 255, 0.75);
+    font-weight: 600;
+    direction: rtl;
 }
 
 /* ─── Current Guess ────────────────────────────────── */

--- a/games/feelings-match/main.js
+++ b/games/feelings-match/main.js
@@ -88,17 +88,19 @@ async function unlockAudio() {
     audioReady = true;
 }
 
-/* RULE: Always cancel before speak(). iOS Safari stacks utterances. */
+/* RULE: Always cancel before speak(). iOS Safari stacks utterances.
+   IMPORTANT: speak() must be called synchronously after cancel() — NOT inside
+   a setTimeout. On iOS Safari, cancel() resets the internal speech permission
+   state; calling speak() in a setTimeout then fires outside the gesture context
+   and produces silent failures. Call speak() synchronously instead. */
 function speakText(text) {
     if (!('speechSynthesis' in window)) return;
     speechSynthesis.cancel();
-    setTimeout(() => {
-        const u = new SpeechSynthesisUtterance(text.replace(/[?!.,;:]/g, ''));
-        u.lang = 'he-IL';
-        u.rate = 0.75;
-        if (hebrewVoice) u.voice = hebrewVoice;
-        speechSynthesis.speak(u);
-    }, 50);
+    const u = new SpeechSynthesisUtterance(text.replace(/[?!.,;:]/g, ''));
+    u.lang = 'he-IL';
+    u.rate = 0.75;
+    if (hebrewVoice) u.voice = hebrewVoice;
+    speechSynthesis.speak(u);
 }
 
 /* Play a short chime tone for feedback */
@@ -391,8 +393,11 @@ function init() {
     addBtn('play-again-btn', startGame);
     addBtn('menu-btn',       () => showScreen('welcome-screen'));
 
-    /* Speaker button — replay current scene description */
+    /* Speaker button — replay current scene description.
+       Re-calls unlockAudio() in case the AudioContext was suspended
+       (e.g. after switching tabs), then speaks immediately. */
     addBtn('speaker-btn', () => {
+        unlockAudio().catch(() => {});
         const item = questions[currentIndex];
         if (item) speakScene(item);
     });


### PR DESCRIPTION
color-code:
- Reveal .feedback-caption (was display:none) so hit/miss text shows after each guess
- Add 3-second timeout to waitForVoices() — onvoiceschanged never fires on some
  Android devices, causing hebrewVoice to stay null and all speech to be silent

feelings-match:
- Make speakText() synchronous (remove setTimeout wrapper): on iOS Safari,
  cancel() resets the speech permission state and calling speak() inside a
  setTimeout then fires outside the gesture context → silent speaker button
- Add unlockAudio().catch(()=>{}) call to speaker button handler so AudioContext
  is resumed if it was suspended (e.g. after tab switch)

game-designer.md:
- Document all three audio rules (synchronous speak, waitForVoices timeout,
  speaker button re-unlock) with code examples and wrong patterns to avoid

https://claude.ai/code/session_015g28SsU7bCrARyc82Ca2fN